### PR TITLE
Feat/bp12

### DIFF
--- a/assets/css/buddytask.css
+++ b/assets/css/buddytask.css
@@ -698,7 +698,7 @@ div.mce-panel{
     outline:none;
     font-weight:200;
     position:relative;
-    top:-15px;
+    top:-30px;
     margin:0;
     padding:0;
     width:100%;
@@ -1059,8 +1059,32 @@ body {
         width: 100%;
     }
 
+    .task-board {
+        overflow: visible !important;
+        height: auto !important;
+    }
+
+    .tasks-list-body {
+        overflow: visible !important;
+        min-height: 200px;
+    }
+
     .task-board-dialog {
         width: 100% !important;
         height: 100% !important;
+        overflow-y: auto;
+    }
+
+    .tasks-list {
+        height: auto !important;
+        min-height: 300px;
+    }
+
+    .tasks-highlight {
+        height: 100px !important;
+    }
+
+    #todo-list .input-todo{
+        top:-15px !important;
     }
 }

--- a/assets/js/buddytask.js
+++ b/assets/js/buddytask.js
@@ -34,6 +34,7 @@ jQuery(function(){
 
     const data = {
         'action' : 'get_board',
+        'group_id': btargs.group_id,
         '_wpnonce': jQuery("input#_wpnonce_get_board").val(),
     };
 
@@ -152,6 +153,7 @@ jQuery(function(){
                 const position = jQuery('#' + list_id).find('.task').length;
                 const data = {
                     'action': 'add_new_task',
+                    'group_id': btargs.group_id,
                     'list_id': list_id,
                     'position': position,
                     '_wpnonce': jQuery("input#_wpnonce_add_new_task").val(),
@@ -412,6 +414,7 @@ jQuery(function(){
         // set ajax data
         const data = {
             'action' : 'edit_task',
+            'group_id': btargs.group_id,
             '_wpnonce': jQuery("input#_wpnonce_edit_task").val(),
             'list_id': list_id,
             'task_id': task_id,
@@ -447,6 +450,7 @@ jQuery(function(){
 
         const data = {
             'action' : 'reorder_task',
+            'group_id': btargs.group_id,
             'list_id': list_id,
             'task_id': task_id,
             'task_index': task_index,
@@ -475,6 +479,7 @@ jQuery(function(){
 
         const data = {
             'action' : 'delete_task',
+            'group_id': btargs.group_id,
             'task_id': task_id,
             '_wpnonce': jQuery("input#_wpnonce_delete_task").val(),
         };
@@ -509,6 +514,7 @@ jQuery(function(){
 
                 const data =  {
                     'action': 'users_autocomplete',
+                    'group_id': btargs.group_id,
                     '_wpnonce': jQuery("input#_wpnonce_users_autocomplete").val(),
                     'term':  request.term,
                     'task_id': task_id,
@@ -547,6 +553,7 @@ jQuery(function(){
 
         const data =  {
             'action': 'add_users_to_assign_list',
+            'group_id': btargs.group_id,
             '_wpnonce': jQuery("input#_wpnonce_add_users_to_assign_list").val(),
             'user_id': user_id
         };
@@ -665,6 +672,7 @@ jQuery(function(){
             if(!isRefreshing) {
                 //Return true to indicate we are expecting data
                 data.refresh_board = true;
+                data.group_id = btargs.group_id;
                 return true;
             }
         });
@@ -682,6 +690,7 @@ jQuery(function(){
         const parent_id = jQuery('#edit-task-id').val();
         const data = {
             'action' : 'get_tasks',
+            'group_id': btargs.group_id,
             'parent_id': parent_id,
             '_wpnonce': jQuery("input#_wpnonce_get_tasks").val(),
         };
@@ -837,6 +846,7 @@ jQuery(function(){
                 label.addClass('autocomplete-loading');
                 const data = {
                     'action' : 'edit_list',
+                    'group_id': btargs.group_id,
                     'id' : id,
                     'name':  newTitle,
                     '_wpnonce': jQuery("input#_wpnonce_edit_list").val(),

--- a/assets/js/jquery.ui.touch-punch.js
+++ b/assets/js/jquery.ui.touch-punch.js
@@ -1,0 +1,233 @@
+(function( factory ) {
+    if ( typeof define === "function" && define.amd ) {
+
+        // AMD. Register as an anonymous module.
+        define([ "jquery", "jquery-ui" ], factory );
+    } else {
+
+        // Browser globals
+        factory( jQuery );
+    }
+}(function ($) {
+
+  // Detect touch support - Windows Surface devices and other touch devices
+  $.mspointer = window.navigator.msPointerEnabled;		
+  $.touch = ( 'ontouchstart' in document
+   	|| 'ontouchstart' in window
+   	|| window.TouchEvent
+   	|| (window.DocumentTouch && document instanceof DocumentTouch)
+   	|| navigator.maxTouchPoints > 0
+   	|| navigator.msMaxTouchPoints > 0
+  );
+
+  // Ignore browsers without touch or mouse support
+  if ((!$.touch && !$.mspointer) || !$.ui.mouse) {
+	return;
+  }
+
+  let mouseProto = $.ui.mouse.prototype,
+      _mouseInit = mouseProto._mouseInit,
+      _mouseDestroy = mouseProto._mouseDestroy,
+      touchHandled, lastClickTime  = 0;
+
+    /**
+    * Get the x,y position of a touch event
+    * @param {Object} event A touch event
+    */
+    function getTouchCoords (event) {
+        return {
+            x: event.originalEvent.changedTouches[0].pageX,
+            y: event.originalEvent.changedTouches[0].pageY
+        };
+    }
+
+  /**
+   * Simulate a mouse event based on a corresponding touch event
+   * @param {Object} event A touch event
+   * @param {String} simulatedType The corresponding mouse event
+   */
+  function simulateMouseEvent (event, simulatedType) {
+
+    // Ignore multi-touch events
+    if (event.originalEvent.touches.length > 1) {
+      return;
+    }
+
+    //Ignore input or textarea elements so user can still enter text
+    if ($(event.target).is("input") || $(event.target).is("textarea")) {
+      return;
+    }
+
+    // Prevent "Ignored attempt to cancel a touchmove event with cancelable=false" errors
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+
+    let touch = event.originalEvent.changedTouches[0],
+        simulatedEvent = new MouseEvent(simulatedType, {
+          bubbles: true,
+          cancelable: true,
+          view:window,
+          screenX:touch.screenX,
+          screenY:touch.screenY,
+          clientX:touch.clientX,
+          clientY:touch.clientY
+        });
+
+    // Dispatch the simulated event to the target element
+    event.target.dispatchEvent(simulatedEvent);
+  }
+
+  /**
+   * Handle the jQuery UI widget's touchstart events
+   * @param {Object} event The widget element's touchstart event
+   */
+  mouseProto._touchStart = function (event) {
+
+    let self = this;
+
+    // Interaction time
+    this._startedMove = event.timeStamp;
+
+    // Track movement to determine if interaction was a click
+    self._startPos = getTouchCoords(event);
+
+    // Ignore the event if another widget is already being handled
+    if (touchHandled || !self._mouseCapture(event.originalEvent.changedTouches[0])) {
+      return;
+    }
+
+    // Set the flag to prevent other widgets from inheriting the touch event
+    touchHandled = true;
+
+    // Track movement to determine if interaction was a click
+    self._touchMoved = false;
+
+    // Simulate the mouseover event
+    simulateMouseEvent(event, 'mouseover');
+
+    // Simulate the mousemove event
+    simulateMouseEvent(event, 'mousemove');
+
+    // Simulate the mousedown event
+    simulateMouseEvent(event, 'mousedown');
+  };
+
+  /**
+   * Handle the jQuery UI widget's touchmove events
+   * @param {Object} event The document's touchmove event
+   */
+  mouseProto._touchMove = function (event) {
+
+    // Ignore event if not handled
+    if (!touchHandled) {
+      return;
+    }
+
+    // Interaction was moved
+    this._touchMoved = true;
+
+    // Simulate the mousemove event
+    simulateMouseEvent(event, 'mousemove');
+  };
+
+  /**
+   * Handle the jQuery UI widget's touchend events
+   * @param {Object} event The document's touchend event
+   */
+  mouseProto._touchEnd = function (event) {
+
+    // Ignore event if not handled
+    if (!touchHandled) {
+      return;
+    }
+
+    // Simulate the mouseup event
+    simulateMouseEvent(event, 'mouseup');
+
+    // Simulate the mouseout event
+    simulateMouseEvent(event, 'mouseout');
+
+    // If the touch interaction did not move, it should trigger a click
+    // Check for this in two ways - length of time of simulation and distance moved
+    // Allow for Apple Stylus to be used also
+    let timeMoving = event.timeStamp - this._startedMove;
+    if (!this._touchMoved || timeMoving < 500) {
+        // Simulate the click event
+        if( event.timeStamp - lastClickTime < 400 )
+            simulateMouseEvent(event, 'dblclick');
+        else
+            simulateMouseEvent(event, 'click');
+        lastClickTime = event.timeStamp;	    
+    } else {
+      let endPos = getTouchCoords(event);
+      if ((Math.abs(endPos.x - this._startPos.x) < 10) && (Math.abs(endPos.y - this._startPos.y) < 10)) {
+
+          // If the touch interaction did not move, it should trigger a click
+          if (!this._touchMoved || event.originalEvent.changedTouches[0].touchType === 'stylus') {
+              // Simulate the click event
+              simulateMouseEvent(event, 'click');
+          }
+      }
+    }
+
+    // Unset the flag to determine the touch movement stopped
+    this._touchMoved = false;
+
+    // Unset the flag to allow other widgets to inherit the touch event
+    touchHandled = false;
+  };
+
+  let _touchStartBound;
+  let _touchMoveBound;
+  let _touchEndBound
+
+  /**
+   * A duck punch of the $.ui.mouse _mouseInit method to support touch events.
+   * This method extends the widget with bound touch event handlers that
+   * translate touch events to mouse events and pass them to the widget's
+   * original mouse event handling methods.
+   */
+  mouseProto._mouseInit = function () {
+
+    let self = this;
+	  
+    // Microsoft Surface Support = remove original touch Action
+    if ($.support.mspointer) {
+      self.element[0].style.msTouchAction = 'none';
+    }	
+
+    _touchStartBound = mouseProto._touchStart.bind(self);
+    _touchMoveBound  = mouseProto._touchMove.bind(self);
+    _touchEndBound   = mouseProto._touchEnd.bind(self);	  
+
+    // Delegate the touch handlers to the widget's element
+    self.element.on({
+      touchstart: _touchStartBound,
+      touchmove: _touchMoveBound,
+      touchend: _touchEndBound
+    });
+
+    // Call the original $.ui.mouse init method
+    _mouseInit.call(self);
+  };
+
+  /**
+   * Remove the touch event handlers
+   */
+  mouseProto._mouseDestroy = function () {
+
+    let self = this;
+
+    // Delegate the touch handlers to the widget's element
+    self.element.off({
+      touchstart: _touchStartBound,
+      touchmove: _touchMoveBound,
+      touchend: _touchEndBound
+    });
+
+    // Call the original $.ui.mouse destroy method
+    _mouseDestroy.call(self);
+  };
+
+}));

--- a/buddytask.php
+++ b/buddytask.php
@@ -3,7 +3,7 @@
 Plugin Name:  BuddyTask
 Plugin URI:
 Description: Adds KanBan like task management boards to Posts, Pages and BuddyPress Groups!
-Version: 1.2.0
+Version: 1.3.0
 Requires at least: 4.6.0
 Tags: BuddyTask, task management, task list, kanban, kan ban, buddypress
 License: GPL V3
@@ -80,7 +80,7 @@ class  BuddyTask {
 	 * @uses plugin_dir_url() to build  buddytask plugin url
 	 */
 	private function setup_globals() {
-		$this->version    = '1.2.0';
+		$this->version    = '1.3.0';
 
 		// Setup some base path and URL information
 		$this->file       = __FILE__;

--- a/buddytask.php
+++ b/buddytask.php
@@ -669,7 +669,7 @@ class  BuddyTask {
         $group_id = isset($_REQUEST['group_id']) ? (int) $_REQUEST['group_id'] : null;;
         $task_uuid = isset($_REQUEST['task_id']) && wp_is_uuid($_REQUEST['task_id']) ? sanitize_text_field($_REQUEST['task_id']) : null;
         $task_title = isset($_REQUEST['task_title']) ? wp_unslash(sanitize_text_field($_REQUEST['task_title'])) : null;
-        $task_description = isset($_REQUEST['task_description']) ? wp_unslash(sanitize_text_field($_REQUEST['task_description'])) : null;
+        $task_description = isset($_REQUEST['task_description']) ? wp_unslash(wp_kses_post($_REQUEST['task_description'])) : null;
         $task_due_date = isset($_REQUEST['task_due_date']) && !empty($_REQUEST['task_due_date']) && is_numeric($_REQUEST['task_due_date']) ?
             floatval($_REQUEST['task_due_date']) : null;
         $task_assign_to = isset($_REQUEST['task_assign_to']) && is_array($_REQUEST['task_assign_to']) ?

--- a/includes/buddytask-component-class.php
+++ b/includes/buddytask-component-class.php
@@ -52,7 +52,12 @@ class  BuddyTask_Component extends BP_Component {
 		$includes = array();
 
 		if ( bp_is_active( 'groups' ) ) {
-			$includes[] = 'buddytask-group-class.php';
+            $is_buddypress_supported = version_compare( bp_get_version(), '12.0.0-alpha', '>=' );
+            if ($is_buddypress_supported) {
+                $includes[] = 'buddytask-group-class.php';
+            } else {
+                $includes[] = 'buddytask-group-legacy-class.php';
+            }
 		}
 
 		parent::includes( $includes );

--- a/includes/buddytask-group-class.php
+++ b/includes/buddytask-group-class.php
@@ -6,39 +6,42 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || exit;
 
-if ( class_exists( 'BP_Group_Extension' ) ) :
+if ( class_exists( 'BP_Group_Extension' ) && bp_is_active( 'groups' ) ) :
 
 /**
  * The  buddytask group class
  *
  * @package  buddytask
  * @since 1.0.0
+ * @version 1.1.0 (BP 12.0+ Compatible)
  */
 class  BuddyTask_Group extends BP_Group_Extension {
     function __construct() {
-        global $bp;
-
-        $enabled = '0';
-        if ( isset( $bp->groups->current_group->id ) ) {
-            $enabled = groups_get_groupmeta( $bp->groups->current_group->id, 'buddytask_enabled', true );
-        }
-
         $args = array(
             'name' => buddytask_get_name(),
             'slug' =>  buddytask_get_slug(),
             'nav_item_position' => 40,
-            'enable_nav_item' =>  $enabled === '1'
+            'show_tab_callback' => array( $this, 'show_tab' )
         );
         parent::init( $args );
     }
 
-    function create_screen( $group_id = null) {
-        global $bp;
+    function show_tab( $group_id = null ) {
 
         if ( ! $group_id ) {
-            $group_id = $bp->groups->current_group->id;
+            $group_id = bp_get_current_group_id();
         }
 
+        $show_tab = 'noone';
+        $active = groups_get_groupmeta( $group_id, 'buddytask_enabled', true );
+        if ( $group_id && $active ) {
+            $show_tab = 'anyone';
+        }
+
+        return $show_tab;
+    }
+
+    function create_screen( $group_id = null) {
         if ( !bp_is_group_creation_step( $this->slug ) )
             return false;
 
@@ -48,10 +51,8 @@ class  BuddyTask_Group extends BP_Group_Extension {
     }
 
     function create_screen_save( $group_id = null) {
-        global $bp;
-
         if ( ! $group_id ) {
-            $group_id = $bp->groups->current_group->id;
+            $group_id = bp_get_current_group_id();
         }
 
         check_admin_referer( 'groups_create_save_' . $this->slug );
@@ -60,17 +61,17 @@ class  BuddyTask_Group extends BP_Group_Extension {
     }
 
     function edit_screen( $group_id = null ) {
-        global $bp;
-
-        if ( !groups_is_user_admin( $bp->loggedin_user->id, $bp->groups->current_group->id ) && ! current_user_can( 'bp_moderate' ) ) {
+       if (! bp_is_group_admin_screen( $this->slug ) ) {
             return false;
         }
 
-        if ( !bp_is_group_admin_screen( $this->slug ) )
-            return false;
-
         if (!$group_id){
-            $group_id = $bp->groups->current_group->id;
+            $group_id = bp_get_current_group_id();
+        }
+
+        // Permission check.
+        if (! groups_is_user_admin( bp_loggedin_user_id(), $group_id ) && ! current_user_can( 'bp_moderate' ) ) {
+            return false;
         }
 
         wp_nonce_field( 'groups_edit_save_' . $this->slug );
@@ -78,19 +79,17 @@ class  BuddyTask_Group extends BP_Group_Extension {
         $this->render_settings($group_id, false);
         ?>
 
-        <input type="submit" name="save" value="Save" />
+        <p><input type="submit" name="save" value="<?php esc_attr_e( 'Save Settings', 'buddytask' );?>" /></p>
         <?php
     }
 
     function edit_screen_save( $group_id = null ) {
-        global $bp;
-
         $save = sanitize_text_field($_POST['save']);
         if ($save == null)
             return false;
 
         if ( !$group_id ) {
-            $group_id = $bp->groups->current_group->id;
+            $group_id = bp_get_current_group_id();
         }
 
         check_admin_referer( 'groups_edit_save_' . $this->slug );
@@ -99,27 +98,39 @@ class  BuddyTask_Group extends BP_Group_Extension {
 
         bp_core_add_message( esc_html__( 'Settings saved successfully', 'buddytask' ) );
 
-        bp_core_redirect( bp_get_group_permalink( $bp->groups->current_group ) . 'admin/' . $this->slug );
+        $group = groups_get_group( $group_id );
+        if ( $group ) {
+            bp_core_redirect( bp_get_group_permalink( $group ). 'admin/'. $this->slug );
+        }
     }
 
     function display( $group_id = null ) {
-        global $bp;
-
-        if (!$group_id) {
-            $group_id = $bp->groups->current_group->id;
+        if (! $group_id ) {
+            $group_id = bp_get_current_group_id();
         }
 
-        if ( groups_is_user_member( $bp->loggedin_user->id, $group_id )
-            || groups_is_user_mod( $bp->loggedin_user->id, $group_id )
-            || groups_is_user_admin( $bp->loggedin_user->id, $group_id )
+        if (! $group_id ) {
+            // Should not happen if nav item is displayed, but as a safeguard.
+            return;
+        }
+
+        // Check membership status.
+        if ( groups_is_user_member( bp_loggedin_user_id(), $group_id )
+            || groups_is_user_mod( bp_loggedin_user_id(), $group_id )
+            || groups_is_user_admin( bp_loggedin_user_id(), $group_id )
             || is_super_admin() ) {
 
             $enabled = groups_get_groupmeta( $group_id, 'buddytask_enabled', true );
             if ( $enabled == 1 ) {
                 $this->get_groups_template_part( 'tasks/home' );
             }
-        } else {
-            echo '<div id="message" class="error"><p>'.esc_html__('This content is only available to group members.', 'buddytask').'</p></div>';
+        }  else {
+            // Display a message for non-members.
+            bp_core_add_message( esc_html__( 'This content is only available to group members.', 'buddytask' ), 'error' );
+            $template = bp_locate_template( 'groups/single/home.php', false, true );
+            if ( $template ) {
+                require $template;
+            }
         }
     }
 
@@ -128,17 +139,19 @@ class  BuddyTask_Group extends BP_Group_Extension {
         $enabled = $is_create ? $defaults['enabled'] : buddytask_is_enabled($group_id);
 
         ?>
-        <div class="wrap">
-            <h4><?php _e(  buddytask_get_name() . ' Settings', 'buddytask' ) ?></h4>
+        <h4><?php echo esc_html( buddytask_get_name(). ' '. __( 'Settings', 'buddytask' ) );?></h4>
 
-            <fieldset>
-                <div class="field-group">
-                    <div class="checkbox">
-                        <label><input type="checkbox" name=" buddytask_enabled" value="1" <?php checked( (bool) $enabled )?>> <?php _e( 'Activate', 'buddytask' ); ?></label>
-                    </div>
+        <fieldset>
+            <div class="field-group">
+                <div class="checkbox">
+                    <label for="buddytask_enabled">
+                        <input type="checkbox" name="buddytask_enabled" id="buddytask_enabled" value="1" <?php checked( $enabled );?>>
+                        <?php esc_html_e( 'Enable tasks for this group.', 'buddytask' );?>
+                    </label>
                 </div>
-            </fieldset>
-        </div>
+                <p class="description"><?php esc_html_e( 'Check this box to activate the tasks feature within this group.', 'buddytask' );?></p>
+            </div>
+        </fieldset>
         <?php
     }
 
@@ -176,10 +189,11 @@ class  BuddyTask_Group extends BP_Group_Extension {
  *
  * @uses bp_register_group_extension() to register the group extension
  */
-function  buddytask_register_group_extension() {
-    bp_register_group_extension( 'buddytask_Group' );
+function buddytask_register_group_extension() {
+    if ( bp_is_active( 'groups' ) ) {
+        bp_register_group_extension( 'BuddyTask_Group' );
+    }
 }
-
 add_action( 'bp_init', 'buddytask_register_group_extension' );
 
 endif;

--- a/includes/buddytask-group-legacy-class.php
+++ b/includes/buddytask-group-legacy-class.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ *  buddytask Groups
+ */
+
+// Exit if accessed directly.
+defined( 'ABSPATH' ) || exit;
+
+if ( class_exists( 'BP_Group_Extension' ) ) :
+
+    /**
+     * The  buddytask group class
+     *
+     * @package  buddytask
+     * @since 1.0.0
+     */
+    class BuddyTask_Group extends BP_Group_Extension {
+        function __construct() {
+            global $bp;
+
+            $enabled = '0';
+            if ( isset( $bp->groups->current_group->id ) ) {
+                $enabled = groups_get_groupmeta( $bp->groups->current_group->id, 'buddytask_enabled', true );
+            }
+
+            $args = array(
+                'name' => buddytask_get_name(),
+                'slug' =>  buddytask_get_slug(),
+                'nav_item_position' => 40,
+                'enable_nav_item' =>  $enabled === '1'
+            );
+            parent::init( $args );
+        }
+
+        function create_screen( $group_id = null) {
+            global $bp;
+
+            if ( ! $group_id ) {
+                $group_id = $bp->groups->current_group->id;
+            }
+
+            if ( !bp_is_group_creation_step( $this->slug ) )
+                return false;
+
+            wp_nonce_field( 'groups_create_save_' . $this->slug );
+
+            $this->render_settings($group_id, true);
+        }
+
+        function create_screen_save( $group_id = null) {
+            global $bp;
+
+            if ( ! $group_id ) {
+                $group_id = $bp->groups->current_group->id;
+            }
+
+            check_admin_referer( 'groups_create_save_' . $this->slug );
+
+            $this->persist_settings($group_id);
+        }
+
+        function edit_screen( $group_id = null ) {
+            global $bp;
+
+            if ( !groups_is_user_admin( $bp->loggedin_user->id, $bp->groups->current_group->id ) && ! current_user_can( 'bp_moderate' ) ) {
+                return false;
+            }
+
+            if ( !bp_is_group_admin_screen( $this->slug ) )
+                return false;
+
+            if (!$group_id){
+                $group_id = $bp->groups->current_group->id;
+            }
+
+            wp_nonce_field( 'groups_edit_save_' . $this->slug );
+
+            $this->render_settings($group_id, false);
+            ?>
+
+            <input type="submit" name="save" value="Save" />
+            <?php
+        }
+
+        function edit_screen_save( $group_id = null ) {
+            global $bp;
+
+            $save = sanitize_text_field($_POST['save']);
+            if ($save == null)
+                return false;
+
+            if ( !$group_id ) {
+                $group_id = $bp->groups->current_group->id;
+            }
+
+            check_admin_referer( 'groups_edit_save_' . $this->slug );
+
+            $this->persist_settings($group_id);
+
+            bp_core_add_message( esc_html__( 'Settings saved successfully', 'buddytask' ) );
+
+            bp_core_redirect( bp_get_group_permalink( $bp->groups->current_group ) . 'admin/' . $this->slug );
+        }
+
+        function display( $group_id = null ) {
+            global $bp;
+
+            if (!$group_id) {
+                $group_id = $bp->groups->current_group->id;
+            }
+
+            if ( groups_is_user_member( $bp->loggedin_user->id, $group_id )
+                || groups_is_user_mod( $bp->loggedin_user->id, $group_id )
+                || groups_is_user_admin( $bp->loggedin_user->id, $group_id )
+                || is_super_admin() ) {
+
+                $enabled = groups_get_groupmeta( $group_id, 'buddytask_enabled', true );
+                if ( $enabled == 1 ) {
+                    $this->get_groups_template_part( 'tasks/home' );
+                }
+            } else {
+                echo '<div id="message" class="error"><p>'.esc_html__('This content is only available to group members.', 'buddytask').'</p></div>';
+            }
+        }
+
+        function render_settings($group_id, $is_create){
+            $defaults =  buddytask_default_settings();
+            $enabled = $is_create ? $defaults['enabled'] : buddytask_is_enabled($group_id);
+
+            ?>
+            <div class="wrap">
+                <h4><?php _e(  buddytask_get_name() . ' Settings', 'buddytask' ) ?></h4>
+
+                <fieldset>
+                    <div class="field-group">
+                        <div class="checkbox">
+                            <label><input type="checkbox" name=" buddytask_enabled" value="1" <?php checked( (bool) $enabled )?>> <?php _e( 'Activate', 'buddytask' ); ?></label>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <?php
+        }
+
+        function persist_settings($group_id){
+            buddytask_groups_update_groupmeta($group_id, 'buddytask_enabled', "0");
+        }
+
+        function get_groups_template_part( $slug ) {
+            add_filter( 'bp_locate_template_and_load', '__return_true'                        );
+            add_filter( 'bp_get_template_stack', array($this, 'set_template_stack'), 10, 1 );
+
+            bp_get_template_part( 'groups/single/' . $slug );
+
+            remove_filter( 'bp_locate_template_and_load', '__return_true' );
+            remove_filter( 'bp_get_template_stack', array($this, 'set_template_stack'), 10);
+        }
+
+        function set_template_stack( $stack = array() ) {
+            if ( empty( $stack ) ) {
+                $stack = array(  buddytask_get_plugin_dir() . 'templates' );
+            } else {
+                $stack[] =  buddytask_get_plugin_dir() . 'templates';
+            }
+
+            return $stack;
+        }
+    }
+
+    /**
+     * Waits for bp_init hook before loading the group extension
+     *
+     * Let's make sure the group id is defined before loading our stuff
+     *
+     * @since 1.0.0
+     *
+     * @uses bp_register_group_extension() to register the group extension
+     */
+    function  buddytask_register_group_extension() {
+        bp_register_group_extension( 'buddytask_Group' );
+    }
+
+    add_action( 'bp_init', 'buddytask_register_group_extension' );
+
+endif;

--- a/readme.txt
+++ b/readme.txt
@@ -2,9 +2,9 @@
 Contributors: cytechltd
 Tags:  BuddyTask, task management, task list, kanban, kan ban, buddypress
 Requires at least: 4.5
-Tested up to: 6.2.2
+Tested up to: 6.8.1
 Requires PHP: 5.3
-Stable tag: 1.2.0
+Stable tag: 1.3.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -64,6 +64,12 @@ Use the support forum of this plugin.
 9. BuddyTask settings inside a BuddyPress Group
 
 == Changelog ==
+
+= 1.3.0 =
+
+* Added support for BuddyPress version 12 and above (no longer requires the BuddyPress Classic plugin)
+* Added support for drag-and-drop tasks on mobile devices
+* Added support for WordPress version 6.8 and above
 
 = 1.2.0 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -69,6 +69,7 @@ Use the support forum of this plugin.
 
 * Added support for BuddyPress version 12 and above (no longer requires the BuddyPress Classic plugin)
 * Added support for drag-and-drop tasks on mobile devices
+* Added support for HTML content in the task description. The description is now sanitized using wp_kses_post(), which allows only permitted HTML tags for post content.
 * Added support for WordPress version 6.8 and above
 
 = 1.2.0 =


### PR DESCRIPTION
* Added support for BuddyPress version 12 and above (no longer requires the BuddyPress Classic plugin)
* Added support for drag-and-drop tasks on mobile devices
* Added support for HTML content in the task description. The description is now sanitized using wp_kses_post(), which allows only permitted HTML tags for post content.
* Added support for WordPress version 6.8 and above